### PR TITLE
fix: api endpoint ver 0.13-beta5

### DIFF
--- a/prometheus_frigate_exporter.py
+++ b/prometheus_frigate_exporter.py
@@ -23,9 +23,9 @@ class CustomCollector(object):
         self.stats_url = _url
         self.process_stats = {}
 
-    def add_metric_process(self, metric, stats, camera_name, pid_name, process_name, cpu_or_memory, process_type):
+    def add_metric_process(self, metric, camera_stats, camera_name, pid_name, process_name, cpu_or_memory, process_type):
         try:
-            pid = str(stats[camera_name][pid_name])
+            pid = str(camera_stats[pid_name])
             label_values = [pid, camera_name, process_name, process_type]
             metric.add_metric(label_values, self.process_stats[pid][cpu_or_memory])
             del self.process_stats[pid][cpu_or_memory]
@@ -69,13 +69,13 @@ class CustomCollector(object):
             add_metric(skipped_fps, camera_name, camera_stats, 'skipped_fps')
             add_metric(detection_enabled, camera_name, camera_stats, 'detection_enabled')
 
-            self.add_metric_process(cpu_usages, stats, camera_name, 'ffmpeg_pid', 'ffmpeg', 'cpu', 'Camera')
-            self.add_metric_process(cpu_usages, stats, camera_name, 'capture_pid', 'capture', 'cpu', 'Camera')
-            self.add_metric_process(cpu_usages, stats, camera_name, 'pid', 'detect', 'cpu', 'Camera')
+            self.add_metric_process(cpu_usages, camera_stats, camera_name, 'ffmpeg_pid', 'ffmpeg', 'cpu', 'Camera')
+            self.add_metric_process(cpu_usages, camera_stats, camera_name, 'capture_pid', 'capture', 'cpu', 'Camera')
+            self.add_metric_process(cpu_usages, camera_stats, camera_name, 'pid', 'detect', 'cpu', 'Camera')
 
-            self.add_metric_process(mem_usages, stats, camera_name, 'ffmpeg_pid', 'ffmpeg', 'mem', 'Camera')
-            self.add_metric_process(mem_usages, stats, camera_name, 'capture_pid', 'capture', 'mem', 'Camera')
-            self.add_metric_process(mem_usages, stats, camera_name, 'pid', 'detect', 'mem', 'Camera')
+            self.add_metric_process(mem_usages, camera_stats, camera_name, 'ffmpeg_pid', 'ffmpeg', 'mem', 'Camera')
+            self.add_metric_process(mem_usages, camera_stats, camera_name, 'capture_pid', 'capture', 'mem', 'Camera')
+            self.add_metric_process(mem_usages, camera_stats, camera_name, 'pid', 'detect', 'mem', 'Camera')
 
         yield camera_fps
         yield detection_fps

--- a/prometheus_frigate_exporter.py
+++ b/prometheus_frigate_exporter.py
@@ -35,6 +35,7 @@ class CustomCollector(object):
     def collect(self):
         stats = json.loads(urlopen(self.stats_url).read())
         self.process_stats = stats['cpu_usages']
+        self.cameras = stats['cameras']
 
         # process stats for cameras, detectors and other
         cpu_usages = GaugeMetricFamily('frigate_cpu_usage_percent', 'Process CPU usage %',
@@ -54,7 +55,7 @@ class CustomCollector(object):
         detection_enabled = GaugeMetricFamily('frigate_detection_enabled', 'Detection enabled for camera',
                                               labels=['camera_name'])
 
-        for camera_name, camera_stats in stats.items():
+        for camera_name, camera_stats in self.cameras.items():
             add_metric(camera_fps, camera_name, camera_stats, 'camera_fps')
             add_metric(detection_fps, camera_name, camera_stats, 'detection_fps')
             add_metric(process_fps, camera_name, camera_stats, 'process_fps')


### PR DESCRIPTION
As mentioned in #3 there is an API change in 0.13 beta 5 
I added quick fix that seams to work for me.
a) I am not sure if I did it efficiently/elegantly 
b) This may need a version change for this exporter, so that people using different frigate versions could select the correct exporter