### PR TITLE
Default exporter port change option

### DIFF
--- a/prometheus_frigate_exporter.py
+++ b/prometheus_frigate_exporter.py
@@ -208,10 +208,11 @@ if __name__ == '__main__':
             "e.g. FRIGATE_STATS_URL=http://<your-frigate-ip>:5000/api/stats")
         exit()
 
-    start_http_server(9100)
+    port = int(os.environ.get('PORT', 9100))
+    start_http_server(port)
 
     logging.info('Started, Frigate API URL: ' + sys.argv[1])
-    logging.info('Metrics at: http://localhost:9100/metrics')
+    logging.info('Metrics at: http://localhost:' + str(port) + '/metrics')
 
     while True:
         time.sleep(1)

--- a/prometheus_frigate_exporter.py
+++ b/prometheus_frigate_exporter.py
@@ -6,6 +6,7 @@ import re
 import time
 import sys
 import logging
+import os
 
 
 def add_metric(metric, label, stats, key, multiplier=1.0):

--- a/prometheus_frigate_exporter.py
+++ b/prometheus_frigate_exporter.py
@@ -201,7 +201,7 @@ if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.INFO)
 
     try:
-        url = sys.argv[1]
+        url = str(os.environ.get('FRIGATE_STATS_URL', 'http://localhost:5000/api/stats'))
         REGISTRY.register(CustomCollector(url))
     except IndexError:
         logging.error(
@@ -212,7 +212,7 @@ if __name__ == '__main__':
     port = int(os.environ.get('PORT', 9100))
     start_http_server(port)
 
-    logging.info('Started, Frigate API URL: ' + sys.argv[1])
+    logging.info('Started, Frigate API URL: ' + url)
     logging.info('Metrics at: http://localhost:' + str(port) + '/metrics')
 
     while True:


### PR DESCRIPTION
Hey,

I run a lot of monitoring on the same remote server, so with VPN config and all that fun I needed to change the default exporter's  port.
This change allows you to set the internal exporter's port using environmental variable `PORT`. If nothing is defined it falls back to 9100.