### PR TITLE
Fix storage paths for frigate_storage_mount_type_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,10 +313,10 @@ frigate_storage_free_bytes{storage="/media/frigate/recordings"} 2e+09
 frigate_storage_free_bytes{storage="/tmp/cache"} 2e+09
 # HELP frigate_storage_mount_type_info Storage mount type
 # TYPE frigate_storage_mount_type_info gauge
-frigate_storage_mount_type_info{mount_type="tmpfs",storage="/"} 1.0
-frigate_storage_mount_type_info{mount_type="ext4",storage="/"} 1.0
-frigate_storage_mount_type_info{mount_type="ext4",storage="/"} 1.0
-frigate_storage_mount_type_info{mount_type="overlay",storage="/"} 1.0
+frigate_storage_mount_type_info{mount_type="tmpfs",storage="/dev/shm"} 1.0
+frigate_storage_mount_type_info{mount_type="ext4",storage="/media/frigate/clips"} 1.0
+frigate_storage_mount_type_info{mount_type="ext4",storage="/media/frigate/recordings"} 1.0
+frigate_storage_mount_type_info{mount_type="overlay",storage="/tmp/cache"} 1.0
 # HELP frigate_storage_total_bytes Storage total bytes
 # TYPE frigate_storage_total_bytes gauge
 frigate_storage_total_bytes{storage="/dev/shm"} 3e+09

--- a/prometheus_frigate_exporter.py
+++ b/prometheus_frigate_exporter.py
@@ -267,7 +267,7 @@ class CustomCollector(object):
         yield temperatures
 
         storage_free = GaugeMetricFamily('frigate_storage_free_bytes', 'Storage free bytes', labels=['storage'])
-        storage_mount_type = InfoMetricFamily('frigate_storage_mount_type', 'Storage mount type', labels=['storage'])
+        storage_mount_type = InfoMetricFamily('frigate_storage_mount_type', 'Storage mount type', labels=['mount_type', 'storage'])
         storage_total = GaugeMetricFamily('frigate_storage_total_bytes', 'Storage total bytes', labels=['storage'])
         storage_used = GaugeMetricFamily('frigate_storage_used_bytes', 'Storage used bytes', labels=['storage'])
 
@@ -276,7 +276,7 @@ class CustomCollector(object):
                 add_metric(storage_free, [storage_path], storage_stats, 'free', 1e6)  # MB to bytes
                 add_metric(storage_total, [storage_path], storage_stats, 'total', 1e6)  # MB to bytes
                 add_metric(storage_used, [storage_path], storage_stats, 'used', 1e6)  # MB to bytes
-                storage_mount_type.add_metric(storage_path, {'mount_type': storage_stats['mount_type']})
+                storage_mount_type.add_metric(storage_path, {'mount_type': storage_stats['mount_type'], 'storage': storage_path})
         except KeyError:
             pass
 


### PR DESCRIPTION
Hello,

Trying to fix https://github.com/bairhys/prometheus-frigate-exporter/issues/9 by setting the `storage` label in `frigate_storage_mount_type_info` to the actual mount path instead to the (defaulted?) `/`.

This solves the duplicate series error in my side and changes the `/metrics` output from:

```python
# HELP frigate_storage_mount_type_info Storage mount type
# TYPE frigate_storage_mount_type_info gauge
frigate_storage_mount_type_info{mount_type="tmpfs",storage="/"} 1.0
frigate_storage_mount_type_info{mount_type="ext4",storage="/"} 1.0
frigate_storage_mount_type_info{mount_type="ext4",storage="/"} 1.0
frigate_storage_mount_type_info{mount_type="tmpfs",storage="/"} 1.0
```

To:

```python
# HELP frigate_storage_mount_type_info Storage mount type
# TYPE frigate_storage_mount_type_info gauge
frigate_storage_mount_type_info{mount_type="tmpfs",storage="/dev/shm"} 1.0
frigate_storage_mount_type_info{mount_type="ext4",storage="/media/frigate/clips"} 1.0
frigate_storage_mount_type_info{mount_type="ext4",storage="/media/frigate/recordings"} 1.0
frigate_storage_mount_type_info{mount_type="tmpfs",storage="/tmp/cache"} 1.0
```

I also updated the sample in the README file to reflect the change.

Thanks,